### PR TITLE
Add unmanaged-state annotation to DevWorkspaceTemplate

### DIFF
--- a/web-terminal-tooling-devworkspacetemplate.yaml
+++ b/web-terminal-tooling-devworkspacetemplate.yaml
@@ -3,6 +3,7 @@ kind: DevWorkspaceTemplate
 metadata:
   annotations:
     controller.devfile.io/allow-import-from: '*'
+    web-terminal.redhat.com/unmanaged-state: "true"
   labels:
     console.openshift.io/terminal: "true"
   name: web-terminal-tooling


### PR DESCRIPTION
#1 の内容を再作成。

Web Terminal再起動時や更新時にもCustom Tooling Imageを使用し続けられるよう、annotationを追加
参考) https://github.com/redhat-developer/web-terminal-operator#configuring-the-custom-default-container